### PR TITLE
decrease build time

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -18,12 +18,6 @@ jobs:
       name: development
       url: https://${{ env.URL }}
     steps:
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.7.0'
-          bundler-cache: true
-      
       # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
       - name: Set GitHub Actions as Commit Author
         run: |
@@ -34,6 +28,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: 'build'
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7.0'
+          bundler-cache: true
       
       - name: Build
         run: |

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           ruby-version: '2.7.0'
           bundler-cache: true
+          working-directory: 'build/'
       
       - name: Build
         run: |

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -35,9 +35,9 @@ jobs:
       - name: Build
         run: |
           cd build
-          gem install bundler
-          bundle install
-          bundle exec jekyll build
+          MAKE="make --jobs 4" gem install bundler
+          MAKE="make --jobs 4" bundle install
+          MAKE="make --jobs 4" bundle exec jekyll build
           cd ..
       
       # bundle exec rake search:init

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -19,7 +19,10 @@ jobs:
       url: https://${{ env.URL }}
     steps:
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7.0'
+          bundler-cache: true
       
       # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
       - name: Set GitHub Actions as Commit Author
@@ -35,7 +38,6 @@ jobs:
       - name: Build
         run: |
           cd build
-          MAKE="make --jobs 4" gem install bundler
           MAKE="make --jobs 4" bundle install
           MAKE="make --jobs 4" bundle exec jekyll build
           cd ..

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Build
         run: |
           cd build
-          MAKE="make --jobs 4" bundle install
           MAKE="make --jobs 4" bundle exec jekyll build
           cd ..
       

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Build Pull Request
         run: |
           cd pr-build
-          gem install bundler
-          bundle install
-          bundle exec jekyll build
+          MAKE="make --jobs 4" gem install bundler
+          MAKE="make --jobs 4" bundle install
+          MAKE="make --jobs 4" bundle exec jekyll build
           cd ..
       
       - name: Checkout temporary deployment target repo

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
+        with:
           bundler-cache: true
       
       # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -37,7 +37,8 @@ jobs:
       url: https://enigmaglass-docs.github.io/${{ env.PR_REPO_NAME }}/
     steps:
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
+          bundler-cache: true
       
       # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
       - name: Set GitHub Actions as Commit Author

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: '2.7.0'
           bundler-cache: true
       
       # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Build Pull Request
         run: |
           cd pr-build
-          MAKE="make --jobs 4" bundle install
           MAKE="make --jobs 4" bundle exec jekyll build
           cd ..
       

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           ruby-version: '2.7.0'
           bundler-cache: true
-          working-directory: 'build/'
+          working-directory: 'pr-build/'
       
       - name: Build Pull Request
         run: |

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           ruby-version: '2.7.0'
           bundler-cache: true
+          working-directory: 'build/'
       
       - name: Build Pull Request
         run: |

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -36,12 +36,6 @@ jobs:
       name: pr-staging
       url: https://enigmaglass-docs.github.io/${{ env.PR_REPO_NAME }}/
     steps:
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.7.0'
-          bundler-cache: true
-      
       # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
       - name: Set GitHub Actions as Commit Author
         run: |
@@ -52,6 +46,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: 'pr-build'
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7.0'
+          bundler-cache: true
       
       - name: Build Pull Request
         run: |

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Build Pull Request
         run: |
           cd pr-build
-          MAKE="make --jobs 4" gem install bundler
           MAKE="make --jobs 4" bundle install
           MAKE="make --jobs 4" bundle exec jekyll build
           cd ..

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
We are now using official ruby setup action instead of the deprecated github action. The official action supports caching gems, which makes it so we don't have to download the gems from the official mirror every time. I also modified the build script to build in parallel on 4 cores. I'm pretty sure the runners are dual core ubuntu machines, which should mean they have 4 logical cores. 

All in all avg build time went from around 2 minutes and 30 seconds to closer to 30 seconds.